### PR TITLE
Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+conwhy
+======
+
+Running on Windows
+------------------
+
+To run the project on Windows, you need to download [the corresponding version
+of SDL library][sdl2-binary] and place it in the same directory as the built
+binary files (i.e. `conwhy/bin/Debug`).
+
+[sdl2-binary]: https://github.com/MonoGame/MonoGame.Dependencies/tree/b7312d1b35456fe722b4f82e01d3b9671ea51912/SDL/Windows

--- a/conwhy/conwhy.fsproj
+++ b/conwhy/conwhy.fsproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>conwhy</RootNamespace>
     <AssemblyName>conwhy</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/conwhy/conwhy.fsproj
+++ b/conwhy/conwhy.fsproj
@@ -20,6 +20,9 @@
     <ErrorReport>prompt</ErrorReport>
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/conwhy/conwhy.fsproj
+++ b/conwhy/conwhy.fsproj
@@ -24,8 +24,10 @@
     <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
+    </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/conwhy/packages.config
+++ b/conwhy/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
   <package id="MonoGame.Framework.DesktopGL" version="3.6.0.1625" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This PR ensures that the project builds and runs on Windows (checked with Windows 10 + Visual Studio 2017) as well as on Linux (checked with NixOS 17.09 + whatever Mono and xbuild versions are defined in `default.nix`).

See my commit messages for details of the changes.

The Windows user/builder will need to execute some manual actions to download SDL2, and currently we haven't satisfactory way of automating that, but hopefully it will be fixed in the next MonoGame release (and already was fixed in the release for .NET Core; unfortunately, we still cannot use MonoGame with .NET Core on NixOS for reasons currently unknown).
  